### PR TITLE
Fixed bam.js to use indexURL if provided

### DIFF
--- a/js/bam/bamReader.js
+++ b/js/bam/bamReader.js
@@ -29,6 +29,7 @@ var igv = (function (igv) {
         this.baiPath = 'gcs' === config.sourceType ?
             igv.translateGoogleCloudURL(config.url + ".bai") :
         config.url + ".bai"; // Todo - deal with Picard convention.  WHY DOES THERE HAVE TO BE 2?
+		this.baiPath = config.indexURL || this.baiPath; // If there is an indexURL provided, use it!
         this.headPath = config.headURL || this.bamPath;
 
         this.samplingWindowSize = config.samplingWindowSize === undefined ? 100 : config.samplingWindowSize;


### PR DESCRIPTION
bam.js currently ignores the indexURL parameter passed in.

This also helps solve the issue with the Picard convention because users can specify their bam index.
